### PR TITLE
Fix PSR-4 Autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">7.0",
-        "craftcms/cms": "^3.0.0-RC1",
+        "craftcms/cms": "^3.0.0",
         "larapack/dd": "^1.1"
     },
     "autoload": {

--- a/src/extensions/CaseExtension.php
+++ b/src/extensions/CaseExtension.php
@@ -4,11 +4,11 @@ namespace lewiscom\twigextensions\extensions;
 
 use Craft;
 use Twig\Extension\AbstractExtension;
-use lewiscom\twigextensions\traits\TwigExtensionsTrait;
+use lewiscom\twigextensions\traits\TwigExtensionTrait;
 
 class CaseExtension extends AbstractExtension
 {
-    use TwigExtensionsTrait;
+    use TwigExtensionTrait;
 
     /**
      * @return string

--- a/src/extensions/ClassExtension.php
+++ b/src/extensions/ClassExtension.php
@@ -4,11 +4,11 @@ namespace lewiscom\twigextensions\extensions;
 
 use Craft;
 use Twig\Extension\AbstractExtension;
-use lewiscom\twigextensions\traits\TwigExtensionsTrait;
+use lewiscom\twigextensions\traits\TwigExtensionTrait;
 
 class ClassExtension extends AbstractExtension
 {
-    use TwigExtensionsTrait;
+    use TwigExtensionTrait;
 
     /**
      * @return string

--- a/src/extensions/DumpDieExtension.php
+++ b/src/extensions/DumpDieExtension.php
@@ -4,11 +4,11 @@ namespace lewiscom\twigextensions\extensions;
 
 use Craft;
 use Twig\Extension\AbstractExtension;
-use lewiscom\twigextensions\traits\TwigExtensionsTrait;
+use lewiscom\twigextensions\traits\TwigExtensionTrait;
 
 class DumpDieExtension extends AbstractExtension
 {
-    use TwigExtensionsTrait;
+    use TwigExtensionTrait;
 
     /**
      * @return string

--- a/src/extensions/PhoneNumberExtension.php
+++ b/src/extensions/PhoneNumberExtension.php
@@ -4,11 +4,11 @@ namespace lewiscom\twigextensions\extensions;
 
 use Craft;
 use Twig\Extension\AbstractExtension;
-use lewiscom\twigextensions\traits\TwigExtensionsTrait;
+use lewiscom\twigextensions\traits\TwigExtensionTrait;
 
 class PhoneNumberExtension extends AbstractExtension
 {
-    use TwigExtensionsTrait;
+    use TwigExtensionTrait;
 
     /**
      * @return string

--- a/src/extensions/RegExpExtension.php
+++ b/src/extensions/RegExpExtension.php
@@ -4,11 +4,11 @@ namespace lewiscom\twigextensions\extensions;
 
 use Craft;
 use Twig\Extension\AbstractExtension;
-use lewiscom\twigextensions\traits\TwigExtensionsTrait;
+use lewiscom\twigextensions\traits\TwigExtensionTrait;
 
 class RegExpExtension extends AbstractExtension
 {
-    use TwigExtensionsTrait;
+    use TwigExtensionTrait;
 
     /**
      * @return string

--- a/src/extensions/RelativeDateExtension.php
+++ b/src/extensions/RelativeDateExtension.php
@@ -4,11 +4,11 @@ namespace lewiscom\twigextensions\extensions;
 
 use Craft;
 use Twig\Extension\AbstractExtension;
-use lewiscom\twigextensions\traits\TwigExtensionsTrait;
+use lewiscom\twigextensions\traits\TwigExtensionTrait;
 
 class RelativeDateExtension extends AbstractExtension
 {
-    use TwigExtensionsTrait;
+    use TwigExtensionTrait;
 
     /**
      * @return string

--- a/src/extensions/StringExtension.php
+++ b/src/extensions/StringExtension.php
@@ -3,11 +3,11 @@
 namespace lewiscom\twigextensions\extensions;
 
 use Twig\Extension\AbstractExtension;
-use lewiscom\twigextensions\traits\TwigExtensionsTrait;
+use lewiscom\twigextensions\traits\TwigExtensionTrait;
 
 class StringExtension extends AbstractExtension
 {
-    use TwigExtensionsTrait;
+    use TwigExtensionTrait;
 
     /**
      * @return string

--- a/src/extensions/TemplateExistsExtension.php
+++ b/src/extensions/TemplateExistsExtension.php
@@ -3,11 +3,11 @@
 namespace lewiscom\twigextensions\extensions;
 
 use Twig\Extension\AbstractExtension;
-use lewiscom\twigextensions\traits\TwigExtensionsTrait;
+use lewiscom\twigextensions\traits\TwigExtensionTrait;
 
 class TemplateExistsExtension extends AbstractExtension
 {
-    use TwigExtensionsTrait;
+    use TwigExtensionTrait;
 
     /**
      * @return string

--- a/src/traits/TwigExtensionTrait.php
+++ b/src/traits/TwigExtensionTrait.php
@@ -2,7 +2,7 @@
 
 namespace lewiscom\twigextensions\traits;
 
-trait TwigExtensionsTrait
+trait TwigExtensionTrait
 {
     /**
      * @param string $name


### PR DESCRIPTION
Change 'TwigExtensionsTrait' to singular 'TwigExtensionTrait'
fixes psr-4 autoload by matching filename
adjust extensions classes where the trait is loaded
